### PR TITLE
Remove invalid bin entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "url": "https://internet-israel.com"
   },
   "bin": {
-    "@barzik/branch-name-lint": "bin/branch-name-lint",
     "branch-name-lint": "bin/branch-name-lint"
   },
   "engines": {


### PR DESCRIPTION
fixes `warning branch-name-lint@1.2.0: Invalid bin entry for "@barzik/branch-name-lint" (in "branch-name-lint").`