### PR TITLE
feat: added test branch with regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,13 +14,23 @@ class BranchNameLint {
 			msgBranchDisallowed: 'Pushing to "%s" is not allowed, use git-flow.',
 			msgPrefixNotAllowed: 'Branch prefix "%s" is not allowed.',
 			msgPrefixSuggestion: 'Instead of "%s" try "%s".',
-			msgSeperatorRequired: 'Branch "%s" must contain a seperator "%s".'
+			msgSeperatorRequired: 'Branch "%s" must contain a seperator "%s".',
+			msgDoesNotMatchRegex: 'Does not match the regex given'
 		};
 
 		this.options = Object.assign(defaultOptions, options);
 		this.branch = this.getCurrentBranch();
 		this.ERROR_CODE = 1;
 		this.SUCCESS_CODE = 0;
+	}
+
+	validateWithRegex() {
+		if (this.options.regex) {
+			const REGEX = new RegExp(this.options.regex);
+			return REGEX.test(this.branch);
+		}
+
+		return true;
 	}
 
 	doValidation() {
@@ -45,6 +55,10 @@ class BranchNameLint {
 
 		if (this.branch.includes(this.options.seperator) === false) {
 			return this.error(this.options.msgSeperatorRequired, this.branch, this.options.seperator);
+		}
+
+		if (!this.validateWithRegex()) {
+			return this.error(this.options.msgBranchDisallowed, this.branch, this.options.regex);
 		}
 
 		if (this.options.prefixes.includes(prefix) === false) {

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,20 @@ Any Valid JSON file with `branchNameLinter` attribute.
 }
 ```
 
+## Usage with regex
+
+In order to check the branch name with a regex you can add a a regex as a string under the branchNameLinter in your config JSON.
+
+```
+{
+    "branchNameLinter": {
+		"regex": "^([A-Z]+-[0-9]+.{5,70})"
+		...
+		"msgDoesNotMatchRegex": "Branch \"%s\" must contain certain characters \"%s\"."
+	}
+}
+```
+
 ## Husky usage
 
 After installation, just add in any husky hook as node modules call.
@@ -92,7 +106,7 @@ branchNameLint();
 #### options
 
 Type: `object`
-Default: 
+Default:
 ```
 {
   prefixes: ['feature', 'hotfix', 'release'],

--- a/test.js
+++ b/test.js
@@ -24,6 +24,13 @@ test('error prints error', t => {
 	t.is(answer, 1);
 });
 
+test('validateWithRegex', t => {
+	const branchNameLint = new BranchNameLint();
+	branchNameLint.options.regex = '^([A-Z]+-[0-9]+.{5,70})';
+	const validation = branchNameLint.validateWithRegex();
+	t.falsy(validation);
+});
+
 test('getCurrentBranch is working', t => {
 	const childProcess = require('child_process');
 	const branchNameLint = new BranchNameLint();


### PR DESCRIPTION
Based on the issue https://github.com/barzik/branch-name-lint/issues/17. By adding a regex field the config you can now use a regex to test your branch as well.