### PR TITLE
bugfix/remove-to-lower-case

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,10 +35,10 @@ class BranchNameLint {
 
 	doValidation() {
 		const parts = this.branch.split(this.options.seperator);
-		const prefix = parts[0].toLowerCase();
+		const prefix = parts[0];
 		let name = null;
 		if (parts[1]) {
-			name = parts[1].toLowerCase();
+			name = parts[1];
 		}
 
 		if (this.options.skip.length > 0 && this.options.skip.includes(this.branch)) {


### PR DESCRIPTION
## WHAT'S NEW

There is no need to lowercasing the branch prefix\name. The lint rules are case sensitive now.

resolves: #27 