### PR TITLE
bugfix/fix-seperator-spelling

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,12 +9,12 @@ class BranchNameLint {
 			banned: ['wip'],
 			skip: [],
 			disallowed: ['master', 'develop', 'staging'],
-			seperator: '/',
+			separator: '/',
 			msgBranchBanned: 'Branches with the name "%s" are not allowed.',
 			msgBranchDisallowed: 'Pushing to "%s" is not allowed, use git-flow.',
 			msgPrefixNotAllowed: 'Branch prefix "%s" is not allowed.',
 			msgPrefixSuggestion: 'Instead of "%s" try "%s".',
-			msgSeperatorRequired: 'Branch "%s" must contain a seperator "%s".',
+			msgseparatorRequired: 'Branch "%s" must contain a separator "%s".',
 			msgDoesNotMatchRegex: 'Does not match the regex given'
 		};
 
@@ -34,7 +34,7 @@ class BranchNameLint {
 	}
 
 	doValidation() {
-		const parts = this.branch.split(this.options.seperator);
+		const parts = this.branch.split(this.options.separator);
 		const prefix = parts[0].toLowerCase();
 		let name = null;
 		if (parts[1]) {
@@ -53,8 +53,8 @@ class BranchNameLint {
 			return this.error(this.options.msgBranchDisallowed, this.branch);
 		}
 
-		if (this.branch.includes(this.options.seperator) === false) {
-			return this.error(this.options.msgSeperatorRequired, this.branch, this.options.seperator);
+		if (this.branch.includes(this.options.separator) === false) {
+			return this.error(this.options.msgseparatorRequired, this.branch, this.options.separator);
 		}
 
 		if (!this.validateWithRegex()) {
@@ -65,8 +65,8 @@ class BranchNameLint {
 			if (this.options.suggestions[prefix]) {
 				this.error(
 					this.options.msgPrefixSuggestion,
-					[prefix, name].join(this.options.seperator),
-					[this.options.suggestions[prefix], name].join(this.options.seperator)
+					[prefix, name].join(this.options.separator),
+					[this.options.suggestions[prefix], name].join(this.options.separator)
 				);
 			} else {
 				this.error(this.options.msgPrefixNotAllowed, prefix);

--- a/readme.md
+++ b/readme.md
@@ -54,12 +54,12 @@ Any Valid JSON file with `branchNameLinter` attribute.
             "develop",
             "staging"
         ],
-        "seperator": "/",
+        "separator": "/",
         "msgBranchBanned": "Branches with the name \"%s\" are not allowed.",
         "msgBranchDisallowed": "Pushing to \"%s\" is not allowed, use git-flow.",
         "msgPrefixNotAllowed": "Branch prefix \"%s\" is not allowed.",
         "msgPrefixSuggestion": "Instead of \"%s\" try \"%s\".",
-        "msgSeperatorRequired": "Branch \"%s\" must contain a seperator \"%s\"."
+        "msgseparatorRequired": "Branch \"%s\" must contain a separator \"%s\"."
     }
 }
 ```
@@ -114,12 +114,12 @@ Default:
   banned: ['wip'],
   skip: [],
   disallowed: ['master', 'develop', 'staging'],
-  seperator: '/',
+  separator: '/',
   msgBranchBanned: 'Branches with the name "%s" are not allowed.',
   msgBranchDisallowed: 'Pushing to "%s" is not allowed, use git-flow.',
   msgPrefixNotAllowed: 'Branch prefix "%s" is not allowed.',
   msgPrefixSuggestion: 'Instead of "%s" try "%s".',
-  msgSeperatorRequired: 'Branch "%s" must contain a seperator "%s".'
+  msgseparatorRequired: 'Branch "%s" must contain a separator "%s".'
 }
 ```
 

--- a/sample-configuration.json
+++ b/sample-configuration.json
@@ -23,11 +23,11 @@
             "develop",
             "staging"
         ],
-        "seperator": "/",
+        "separator": "/",
         "msgBranchBanned": "Branches with the name \"%s\" are not allowed.",
         "msgBranchDisallowed": "Pushing to \"%s\" is not allowed, use git-flow.",
         "msgPrefixNotAllowed": "Branch prefix \"%s\" is not allowed.",
         "msgPrefixSuggestion": "Instead of \"%s\" try \"%s\".",
-        "msgSeperatorRequiredL": "Branch \"%s\" must contain a seperator \"%s\"."
+        "msgseparatorRequiredL": "Branch \"%s\" must contain a separator \"%s\"."
     }
 }

--- a/test.js
+++ b/test.js
@@ -19,7 +19,7 @@ test('See that constructor accept custom options', t => {
 test('error prints error', t => {
 	const branchNameLint = new BranchNameLint();
 	const callback = sinon.stub(console, 'error');
-	const answer = branchNameLint.error('Branch "%s" must contain a seperator "%s".', 'test1', 'test2');
+	const answer = branchNameLint.error('Branch "%s" must contain a separator "%s".', 'test1', 'test2');
 	t.truthy(callback);
 	t.is(answer, 1);
 });
@@ -58,7 +58,7 @@ test('doValidation is throwing error on prefixes', t => {
 	childProcess.execFileSync.restore();
 });
 
-test('doValidation is throwing error on seperator', t => {
+test('doValidation is throwing error on separator', t => {
 	const childProcess = require('child_process');
 	sinon.stub(childProcess, 'execFileSync').returns('feature-valid-name');
 	const branchNameLint = new BranchNameLint();


### PR DESCRIPTION
# WHAT'S NEW

The separator is spelled as "seperator" all over the code and in the options as well.

Resolves #28 