### PR TITLE
fix: more prominent error output

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ class BranchNameLint {
     this.branch = this.getCurrentBranch();
     this.ERROR_CODE = 1;
     this.SUCCESS_CODE = 0;
+    this.CONSOLE_ERROR_OUTPUT_STYLE = '\x1b[41m\x1b[37m%s\x1b[0m';
   }
 
   validateWithRegex() {
@@ -88,7 +89,10 @@ class BranchNameLint {
   }
 
   error() {
-    console.error('Branch name lint fail!', Reflect.apply(util.format, null, arguments)); // eslint-disable-line prefer-rest-params
+    // eslint-disable-next-line no-console
+    console.error(`\n${this.CONSOLE_ERROR_OUTPUT_STYLE}`, 'Branch name linting failed!');
+    // eslint-disable-next-line no-console, prefer-rest-params
+    console.error(`${this.CONSOLE_ERROR_OUTPUT_STYLE}\n`, Reflect.apply(util.format, null, arguments));
     return this.ERROR_CODE;
   }
 }


### PR DESCRIPTION
This PR makes error output more prominent.

To avoid adding extra dependencies following suggestion was used: [StackOverflow: How to change NodeJS console color](https://stackoverflow.com/questions/9781218/how-to-change-node-jss-console-font-color/13336745)

Result:
![shot_210820_160929](https://user-images.githubusercontent.com/10243265/130247505-e4c50444-b3a6-4c9c-aff6-c0fd98ba35ef.png)

Closes: #42 
