### PR TITLE
Cleaning up error output of cli on linting fail

### DIFF
--- a/bin/branch-name-lint
+++ b/bin/branch-name-lint
@@ -26,7 +26,7 @@ class BranchNameLintCli {
 		const branchNameLint = new BranchNameLint(this.options);
 		const answer = branchNameLint.doValidation();
 		if (answer === 1) {
-			throw new Error('Branch lint error');
+			process.exit(1);
 		}
 	}
 


### PR DESCRIPTION
PR implementing the suggestion in #42 to switch from throwing an error to using `process.exit(1)` on linting failure .

This change should help make the output look clearer:

<img width="661" alt="branch-name-lint-output" src="https://user-images.githubusercontent.com/35773406/136429240-66decae5-cba7-45c2-a3c3-9e0d9fa18d2a.png">

I also quickly merged your `feature/add-e2e` branch into a [test branch](https://github.com/Ben-Ryder/branch-name-lint/tree/feature/cli-error-handling-testing) and becuase the exit code is still the same, it looks like the tests still pass ok:

<img width="743" alt="branch-name-lint-test-result" src="https://user-images.githubusercontent.com/35773406/136430430-b9e5a3a2-e6d3-405c-8da6-196f320845dd.png">

Fixes #42 
