### PR TITLE
fix: Use correct error message when regex validation fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fix incorrect error message upon regex validation failure.
+
 ## [2.1.0] - 2021-06-11
 ### Added
 - optional `regexOptions`.

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ class BranchNameLint {
     }
 
     if (!this.validateWithRegex()) {
-      return this.error(this.options.msgBranchDisallowed, this.branch, this.options.regex);
+      return this.error(this.options.msgDoesNotMatchRegex, this.branch, this.options.regex);
     }
 
     if (this.options.prefixes.includes(prefix) === false) {

--- a/test.js
+++ b/test.js
@@ -107,6 +107,21 @@ test('doValidation is throwing error on banned', (t) => {
   childProcess.execFileSync.restore();
 });
 
+test('doValidation is using correct error message on regex mismatch', (t) => {
+  const childProcess = require('child_process');
+  sinon.stub(childProcess, 'execFileSync').returns('feature/invalid_characters');
+  const branchNameLint = new BranchNameLint({
+    msgDoesNotMatchRegex: 'my error message',
+    regex: '^[a-z0-9/-]+$',
+    regexOptions: 'i'
+  });
+  const errorStub = sinon.stub(branchNameLint, 'error');
+  branchNameLint.doValidation();
+  t.true(errorStub.calledWith('my error message', 'feature/invalid_characters', '^[a-z0-9/-]+$'));
+  errorStub.restore();
+  childProcess.execFileSync.restore();
+});
+
 test('doValidation is passing on skip', (t) => {
   const childProcess = require('child_process');
   sinon.stub(childProcess, 'execFileSync').returns('develop');


### PR DESCRIPTION
Use `msgDoesNotMatchRegex` rather than `msgBranchDisallowed` when the branch name does not pass the regex validation.