### PR TITLE
adding branch name as a variable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
       
       # Add branch name linting step using GITHUB_REF (default value)
       - name: Lint branch name
+        run: echo running on branch ${GITHUB_REF##*/}
         run: npx branch-name-lint
         env:
           GITHUB_REF: ${{ github.ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       - run: npm install
       - run: npm test
       
-      # Add branch name linting step using environment variable feature
+      # Add branch name linting step using GITHUB_REF (default value)
       - name: Lint branch name
         run: npx branch-name-lint
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,5 +36,5 @@ jobs:
       
       # Add branch name linting step using GITHUB_REF (default value)
       - name: Lint branch name
-        run: echo running on branch ${GITHUB_REF##*/}
+        run: echo ${GITHUB_HEAD_REF}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
       # Add branch name linting step using GITHUB_REF (default value)
       - name: Lint branch name
         run: echo running on branch ${GITHUB_REF##*/}
+        run: echo running on branch ${GITHUB_REF##*/}
         run: npx branch-name-lint
         env:
           GITHUB_REF: ${{ github.ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,5 +37,4 @@ jobs:
       # Add branch name linting step using GITHUB_REF (default value)
       - name: Lint branch name
         run: echo running on branch ${GITHUB_REF##*/}
-        env:
-          GITHUB_REF: ${{ github.ref }}
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,3 +33,9 @@ jobs:
           architecture: ${{ matrix.architecture }}
       - run: npm install
       - run: npm test
+      
+      # Add branch name linting step using environment variable feature
+      - name: Lint branch name
+        run: npx branch-name-lint
+        env:
+          GITHUB_REF: ${{ github.ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,9 @@ jobs:
     name: Branch Lint Name ${{ matrix.node_version }} - ${{ matrix.architecture }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+      # Add branch name linting step using GITHUB_REF (default value)
+      - name: Lint branch name
+        run: echo ${{GITHUB_HEAD_REF}}
       - name: Setup node
         uses: actions/setup-node@v2
         with:
@@ -34,7 +37,5 @@ jobs:
       - run: npm install
       - run: npm test
       
-      # Add branch name linting step using GITHUB_REF (default value)
-      - name: Lint branch name
-        run: echo ${GITHUB_HEAD_REF}
+
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,5 @@ jobs:
       # Add branch name linting step using GITHUB_REF (default value)
       - name: Lint branch name
         run: echo running on branch ${GITHUB_REF##*/}
-        run: echo running on branch ${GITHUB_REF##*/}
-        run: npx branch-name-lint
         env:
           GITHUB_REF: ${{ github.ref }}

--- a/bin/branch-name-lint
+++ b/bin/branch-name-lint
@@ -8,16 +8,24 @@ const BranchNameLint = require('../index');
 
 const cli = meow(`
 	Usage
-	  $ npx branch-name-lint [configuration-file.json|configuration-file.js]
+	  $ npx branch-name-lint [configuration-file.json|configuration-file.js] [options]
 
 	Options
-	  --help - to get this screen
+	  --help             - to get this screen
+	  --branch <name>    - specify branch name manually (overrides environment variable)
+
+	Environment Variables
+	  GITHUB_REF         - can be used to specify branch name (e.g., refs/heads/feature-branch-1)
 
 	Examples
 	  $ branch-name-lint
 	  Use default configutation or the configuration specified in package.json to validate & lint the branch name.
 	  $ branch-name-lint [configuration-file.json|configuration-file.js]
 	  Use configutation file to validate & lint the branch name.
+	  $ branch-name-lint --branch feature/my-branch
+	  Lint a specific branch name instead of the current git branch.
+	  $ GITHUB_REF=refs/heads/feature/my-branch branch-name-lint
+	  Use branch name from environment variable.
 `);
 const configFileName = cli.input[0];
 

--- a/bin/branch-name-lint
+++ b/bin/branch-name-lint
@@ -15,7 +15,10 @@ const cli = meow(`
 	  --branch <name>    - specify branch name manually (overrides environment variable)
 
 	Environment Variables
-	  GITHUB_REF         - can be used to specify branch name (e.g., refs/heads/feature-branch-1)
+	  GITHUB_REF         - used by default, automatically extracts branch name from refs/heads/ format
+
+	Configuration
+	  branchEnvVariable  - configure which environment variable to use (defaults to GITHUB_REF)
 
 	Examples
 	  $ branch-name-lint
@@ -24,8 +27,10 @@ const cli = meow(`
 	  Use configutation file to validate & lint the branch name.
 	  $ branch-name-lint --branch feature/my-branch
 	  Lint a specific branch name instead of the current git branch.
-	  $ GITHUB_REF=refs/heads/feature/my-branch branch-name-lint
-	  Use branch name from environment variable.
+	  $ GITHUB_REF=refs/heads/feature-branch-1 branch-name-lint
+	  Use branch name from GITHUB_REF (automatically extracts from refs/heads/).
+	  $ MY_CUSTOM_VAR=feature/my-branch branch-name-lint config-with-custom-var.json
+	  Use a custom environment variable (requires "branchEnvVariable": "MY_CUSTOM_VAR" in config).
 `);
 const configFileName = cli.input[0];
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const childProcess = require('child_process');
 const util = require('util');
 
 class BranchNameLint {
-  constructor(options) {
+  constructor(options = {}) {
     const defaultOptions = {
       prefixes: ['feature', 'hotfix', 'release'],
       suggestions: {
@@ -18,7 +18,7 @@ class BranchNameLint {
       msgPrefixSuggestion: 'Instead of "%s" try "%s".',
       msgseparatorRequired: 'Branch "%s" must contain a separator "%s".',
       msgDoesNotMatchRegex: 'Branch "%s" does not match the allowed pattern: "%s"',
-      branchEnvVariable: 'GITHUB_REF',
+      // No default value for branchEnvVariable to maintain backward compatibility
     };
 
     this.options = Object.assign(defaultOptions, options);
@@ -101,9 +101,9 @@ class BranchNameLint {
       }
     }
     
-    // Only check for environment variable if branchEnvVariable is explicitly provided in options
-    // This maintains backward compatibility with existing behavior
-    if (this.options.branchEnvVariable !== undefined && process.env[this.options.branchEnvVariable]) {
+    // Only check for environment variable if branchEnvVariable is explicitly set
+    // This ensures backward compatibility
+    if (this.options.branchEnvVariable && process.env[this.options.branchEnvVariable]) {
       let branchName = process.env[this.options.branchEnvVariable].trim();
       
       // Special handling for GITHUB_REF to extract branch name from refs/heads/ format

--- a/index.js
+++ b/index.js
@@ -101,15 +101,16 @@ class BranchNameLint {
       }
     }
     
-    // Check if branch is specified as an environment variable
+    // Check if branch is specified via the configured environment variable
     if (this.options.branchEnvVariable && process.env[this.options.branchEnvVariable]) {
-      const envBranch = process.env[this.options.branchEnvVariable];
+      let branchName = process.env[this.options.branchEnvVariable].trim();
       
-      // Only extract from refs/heads/ if the env variable is specifically GITHUB_REF
-      if (this.options.branchEnvVariable === 'GITHUB_REF' && envBranch.startsWith('refs/heads/')) {
-        return envBranch.replace('refs/heads/', '').trim();
+      // Special handling for GITHUB_REF to extract branch name from refs/heads/ format
+      if (this.options.branchEnvVariable === 'GITHUB_REF' && branchName.startsWith('refs/heads/')) {
+        branchName = branchName.replace('refs/heads/', '');
       }
-      return envBranch.trim();
+      
+      return branchName;
     }
     
     // Fall back to git command if no branch is specified via environment variable or CLI

--- a/index.js
+++ b/index.js
@@ -101,8 +101,9 @@ class BranchNameLint {
       }
     }
     
-    // Check if branch is specified via the configured environment variable
-    if (this.options.branchEnvVariable && process.env[this.options.branchEnvVariable]) {
+    // Only check for environment variable if branchEnvVariable is explicitly provided in options
+    // This maintains backward compatibility with existing behavior
+    if (this.options.branchEnvVariable !== undefined && process.env[this.options.branchEnvVariable]) {
       let branchName = process.env[this.options.branchEnvVariable].trim();
       
       // Special handling for GITHUB_REF to extract branch name from refs/heads/ format

--- a/tests/e2e-test.js
+++ b/tests/e2e-test.js
@@ -29,6 +29,7 @@ const JSON_CONFIG_PATH = path.join(__dirname, 'sample-configuration.json');
 const JS_CONFIG_PATH = path.join(__dirname, 'sample-configuration.js');
 const DISABLED_CONFIG_PATH = path.join(TEST_DIR, 'disabled-config.json');
 const PROJECT_ROOT = path.join(__dirname, '..');
+const ENV_CONFIG_PATH = path.join(TEST_DIR, 'env-config.json');
 
 // Utility function to execute commands with better error handling
 function runCommand(cmd, options = {}) {
@@ -159,14 +160,25 @@ console.log('   ✅ Lint correctly passed for branch with disabled checks');
 // Test with environment variables and CLI options
 console.log('\n8️⃣  Testing with environment variables and CLI options...');
 
+// Create a configuration file that includes the branchEnvVariable option
+const envConfig = {
+  branchNameLinter: {
+    prefixes: ['feature', 'hotfix', 'release'],
+    separator: '/',
+    branchEnvVariable: 'GITHUB_REF'
+  }
+};
+fs.writeFileSync(ENV_CONFIG_PATH, JSON.stringify(envConfig, null, 2));
+console.log(`   Created env variable config at: ${ENV_CONFIG_PATH}`);
+
 // First test with environment variable GITHUB_REF
 console.log('\n   Testing with GITHUB_REF environment variable (refs format)...');
-const envResult = runCommand(`GITHUB_REF=refs/heads/feature/env-branch npx branch-name-lint ${JSON_CONFIG_PATH}`);
+const envResult = runCommand(`GITHUB_REF=refs/heads/feature/env-branch npx branch-name-lint ${ENV_CONFIG_PATH}`);
 console.log('   ✅ Lint correctly passed using GITHUB_REF environment variable');
 
 // Test with direct branch name format
 console.log('\n   Testing with GITHUB_REF environment variable (direct format)...');
-const directEnvResult = runCommand(`GITHUB_REF=feature/direct-env npx branch-name-lint ${JSON_CONFIG_PATH}`);
+const directEnvResult = runCommand(`GITHUB_REF=feature/direct-env npx branch-name-lint ${ENV_CONFIG_PATH}`);
 console.log('   ✅ Lint correctly passed using direct branch name in environment variable');
 
 // Test with CLI option
@@ -186,12 +198,12 @@ if (!invalidCliResult.success) {
 
 // Test environment variable priority (CLI should override env var)
 console.log('\n   Testing CLI option overriding environment variable...');
-const priorityResult = runCommand(`GITHUB_REF=refs/heads/invalid-branch npx branch-name-lint ${JSON_CONFIG_PATH} --branch feature/override-branch`);
+const priorityResult = runCommand(`GITHUB_REF=refs/heads/invalid-branch npx branch-name-lint ${ENV_CONFIG_PATH} --branch feature/override-branch`);
 console.log('   ✅ Lint correctly passed with CLI option overriding environment variable');
 
 // Add specific test for GitHub-style refs extraction
 console.log('\n   Testing GitHub-style refs extraction from GITHUB_REF...');
-const githubRefResult = runCommand(`GITHUB_REF=refs/heads/feature/github-format npx branch-name-lint ${JSON_CONFIG_PATH}`);
+const githubRefResult = runCommand(`GITHUB_REF=refs/heads/feature/github-format npx branch-name-lint ${ENV_CONFIG_PATH}`);
 console.log('   ✅ Lint correctly passed using extracted branch name from GITHUB_REF');
 
 // Test with a custom env variable that contains refs/heads/ but doesn't extract it

--- a/tests/test.js
+++ b/tests/test.js
@@ -320,28 +320,43 @@ test('doValidation is throwing error on banned', () => {
 });
 
 test('doValidation is using correct error message on regex mismatch', () => {
-  sinon.stub(childProcess, 'execFileSync').returns('feature/invalid_characters');
-  const branchNameLint = new BranchNameLint({
-    msgDoesNotMatchRegex: 'my error message',
-    regex: '^[a-z0-9/-]+$',
-    regexOptions: 'i',
-  });
-  const errorStub = sinon.stub(branchNameLint, 'error');
-  branchNameLint.doValidation();
-  assert(errorStub.calledWith('my error message', 'feature/invalid_characters', '^[a-z0-9/-]+$'));
-  errorStub.restore();
-  childProcess.execFileSync.restore();
+  // Ensure no environment variables are interfering
+  const originalEnv = process.env;
+  try {
+    process.env = {}; // Clear environment variables for this test
+    
+    sinon.stub(childProcess, 'execFileSync').returns('feature/invalid_characters');
+    const branchNameLint = new BranchNameLint({
+      msgDoesNotMatchRegex: 'my error message',
+      regex: '^[a-z0-9/-]+$',
+      regexOptions: 'i',
+    });
+    const errorStub = sinon.stub(branchNameLint, 'error');
+    branchNameLint.doValidation();
+    assert(errorStub.calledWith('my error message', 'feature/invalid_characters', '^[a-z0-9/-]+$'));
+  } finally {
+    process.env = originalEnv; // Restore environment variables
+    sinon.restore();
+  }
 });
 
 test('doValidation is passing on skip', () => {
-  sinon.stub(childProcess, 'execFileSync').returns('develop');
-  const mockOptions = {
-    skip: ['develop'],
-  };
-  const branchNameLint = new BranchNameLint(mockOptions);
-  const result = branchNameLint.doValidation();
-  assert.strictEqual(result, branchNameLint.SUCCESS_CODE);
-  childProcess.execFileSync.restore();
+  // Ensure no environment variables are interfering
+  const originalEnv = process.env;
+  try {
+    process.env = {}; // Clear environment variables for this test
+    
+    sinon.stub(childProcess, 'execFileSync').returns('develop');
+    const mockOptions = {
+      skip: ['develop'],
+    };
+    const branchNameLint = new BranchNameLint(mockOptions);
+    const result = branchNameLint.doValidation();
+    assert.strictEqual(result, branchNameLint.SUCCESS_CODE);
+  } finally {
+    process.env = originalEnv; // Restore environment variables
+    sinon.restore();
+  }
 });
 
 test('doValidation applies suggestions', () => {

--- a/tests/test.js
+++ b/tests/test.js
@@ -68,22 +68,44 @@ test('validateWithRegex - fail', () => {
 });
 
 test('validateWithRegex - pass with correct regex', () => {
-  sinon.stub(childProcess, 'execFileSync').returns('regex-pattern-test');
-  const branchNameLint = new BranchNameLint();
-  branchNameLint.options.regex = '^regex.*-test$';
-  const validation = branchNameLint.validateWithRegex();
-  assert(validation);
-  childProcess.execFileSync.restore();
+  // Save original environment to restore later
+  const originalEnv = process.env;
+  try {
+    // Clear environment variables for this test
+    process.env = {};
+    
+    sinon.stub(childProcess, 'execFileSync').returns('regex-pattern-test');
+    const branchNameLint = new BranchNameLint();
+    branchNameLint.branch = 'regex-pattern-test'; // Explicitly set branch
+    branchNameLint.options.regex = '^regex.*-test$';
+    const validation = branchNameLint.validateWithRegex();
+    assert(validation);
+  } finally {
+    // Restore environment
+    process.env = originalEnv;
+    sinon.restore();
+  }
 });
 
 test('validateWithRegex and options', () => {
-  sinon.stub(childProcess, 'execFileSync').returns('REGEX-PATTERN-TEST');
-  const branchNameLint = new BranchNameLint();
-  branchNameLint.options.regex = '^regex.*-test$';
-  branchNameLint.options.regexOptions = 'i';
-  const validation = branchNameLint.validateWithRegex();
-  assert(validation);
-  childProcess.execFileSync.restore();
+  // Save original environment to restore later
+  const originalEnv = process.env;
+  try {
+    // Clear environment variables for this test
+    process.env = {};
+    
+    sinon.stub(childProcess, 'execFileSync').returns('REGEX-PATTERN-TEST');
+    const branchNameLint = new BranchNameLint();
+    branchNameLint.branch = 'REGEX-PATTERN-TEST'; // Explicitly set branch
+    branchNameLint.options.regex = '^regex.*-test$';
+    branchNameLint.options.regexOptions = 'i';
+    const validation = branchNameLint.validateWithRegex();
+    assert(validation);
+  } finally {
+    // Restore environment
+    process.env = originalEnv;
+    sinon.restore();
+  }
 });
 
 test('validateWithRegex - invalid regex pattern', () => {
@@ -93,11 +115,22 @@ test('validateWithRegex - invalid regex pattern', () => {
 });
 
 test('getCurrentBranch is working', () => {
-  const branchNameLint = new BranchNameLint();
-  sinon.stub(childProcess, 'execFileSync').returns('branch mock name');
-  const name = branchNameLint.getCurrentBranch();
-  assert.strictEqual(name, 'branch mock name');
-  childProcess.execFileSync.restore();
+  // Save original environment to restore later
+  const originalEnv = process.env;
+  
+  try {
+    // Clear environment variables for this test
+    process.env = {};
+    
+    const branchNameLint = new BranchNameLint();
+    sinon.stub(childProcess, 'execFileSync').returns('branch mock name');
+    const name = branchNameLint.getCurrentBranch();
+    assert.strictEqual(name, 'branch mock name');
+  } finally {
+    // Restore environment
+    process.env = originalEnv;
+    sinon.restore();
+  }
 });
 
 // New test for environment variable branch specification
@@ -280,11 +313,22 @@ test('getCurrentBranch uses direct branch name from GITHUB_REF if no refs/heads/
 });
 
 test('doValidation is working', () => {
-  sinon.stub(childProcess, 'execFileSync').returns('feature/valid-name');
-  const branchNameLint = new BranchNameLint();
-  const result = branchNameLint.doValidation();
-  assert.strictEqual(result, branchNameLint.SUCCESS_CODE);
-  childProcess.execFileSync.restore();
+  // Save original environment to restore later
+  const originalEnv = process.env;
+  
+  try {
+    // Clear environment variables for this test
+    process.env = {};
+    
+    sinon.stub(childProcess, 'execFileSync').returns('feature/valid-name');
+    const branchNameLint = new BranchNameLint();
+    const result = branchNameLint.doValidation();
+    assert.strictEqual(result, branchNameLint.SUCCESS_CODE);
+  } finally {
+    // Restore environment
+    process.env = originalEnv;
+    sinon.restore();
+  }
 });
 
 test('doValidation is throwing error on prefixes', () => {


### PR DESCRIPTION
# Description

Adding a branch as an env variable. If GITHUB_REF is used, it extracts it by using:
```
 $ GITHUB_REF=refs/heads/feature-branch-1
$ echo ${GITHUB_REF##*/}
feature-branch-1
```

Fixes #46 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
