### PR TITLE
adding branch name as a variable

### DIFF
--- a/.github/branch-name-lint.json
+++ b/.github/branch-name-lint.json
@@ -1,0 +1,21 @@
+{
+  "branchNameLinter": {
+    "prefixes": ["feature", "hotfix", "release", "docs", "chore", "fix", "ci", "test", "refactor", "perf"],
+    "suggestions": {
+      "features": "feature",
+      "feat": "feature", 
+      "fix": "hotfix", 
+      "releases": "release"
+    },
+    "banned": ["wip"],
+    "skip": ["main", "master", "develop", "staging"],
+    "disallowed": [],
+    "separator": "/",
+    "branchNameEnvVariable": "GITHUB_BRANCH_NAME",
+    "msgBranchBanned": "Branches with the name \"%s\" are not allowed.",
+    "msgBranchDisallowed": "Pushing to \"%s\" is not allowed, use git-flow.",
+    "msgPrefixNotAllowed": "Branch prefix \"%s\" is not allowed.",
+    "msgPrefixSuggestion": "Instead of \"%s\" try \"%s\".",
+    "msgSeparatorRequired": "Branch \"%s\" must contain a separator \"%s\"."
+  }
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
             echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
           fi
       - name: Check branch name
-        run: node ./bin/branch-name-lint .github/branch-name-lint.json
+        run: npx branch-name-lint .github/branch-name-lint.json
         env:
           GITHUB_BRANCH_NAME: ${{ env.BRANCH_NAME }}
       - run: npm test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,11 +34,16 @@ jobs:
       - run: npm install
       - name: Extract branch name
         shell: bash
-        run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            # For pull requests, use the head branch name
+            echo "BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_ENV
+          else
+            # For pushes, extract from GITHUB_REF
+            echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          fi
       - name: Check branch name
         run: node ./bin/branch-name-lint .github/branch-name-lint.json
         env:
           GITHUB_BRANCH_NAME: ${{ env.BRANCH_NAME }}
-        # Skip this step on PRs by using a conditional
-        if: github.event_name == 'push'
       - run: npm test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,4 +32,13 @@ jobs:
           node-version: ${{ matrix.node_version }}
           architecture: ${{ matrix.architecture }}
       - run: npm install
+      - name: Extract branch name
+        shell: bash
+        run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+      - name: Check branch name
+        run: node ./bin/branch-name-lint .github/branch-name-lint.json
+        env:
+          GITHUB_BRANCH_NAME: ${{ env.BRANCH_NAME }}
+        # Skip this step on PRs by using a conditional
+        if: github.event_name == 'push'
       - run: npm test

--- a/bin/branch-name-lint
+++ b/bin/branch-name-lint
@@ -11,19 +11,34 @@ const cli = meow(`
 	  $ npx branch-name-lint [configuration-file.json|configuration-file.js]
 
 	Options
-	  --help - to get this screen
+	  --help  - to get this screen
+	  --branch - specify a custom branch name to check instead of the current git branch
 
 	Examples
 	  $ branch-name-lint
 	  Use default configutation or the configuration specified in package.json to validate & lint the branch name.
 	  $ branch-name-lint [configuration-file.json|configuration-file.js]
 	  Use configutation file to validate & lint the branch name.
-`);
+	  $ branch-name-lint --branch feature/my-new-feature
+	  Validate a specific branch name.
+`, {
+	flags: {
+		branch: {
+			type: 'string'
+		}
+	}
+});
 const configFileName = cli.input[0];
 
 class BranchNameLintCli {
 	constructor() {
 		this.options = this.loadConfiguration(configFileName);
+		
+		// Apply command line branch option if provided
+		if (cli.flags.branch) {
+			this.options.branch = cli.flags.branch;
+		}
+		
 		const branchNameLint = new BranchNameLint(this.options);
 		const answer = branchNameLint.doValidation();
 		if (answer === 1) {

--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@ class BranchNameLint {
       msgPrefixSuggestion: 'Instead of "%s" try "%s".',
       msgseparatorRequired: 'Branch "%s" must contain a separator "%s".',
       msgDoesNotMatchRegex: 'Branch "%s" does not match the allowed pattern: "%s"',
+      branch: false,
+      branchNameEnvVariable: false,
     };
 
     this.options = Object.assign(defaultOptions, options);
@@ -92,6 +94,17 @@ class BranchNameLint {
   }
 
   getCurrentBranch() {
+    // First check if a custom branch name was provided via options
+    if (this.options.branch) {
+      return this.options.branch;
+    }
+    
+    // Then check if an environment variable name was provided and has a value
+    if (this.options.branchNameEnvVariable && process.env[this.options.branchNameEnvVariable]) {
+      return process.env[this.options.branchNameEnvVariable];
+    }
+    
+    // Fall back to git command if no custom branch name is provided
     const branch = childProcess.execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD']).toString();
     this.branch = branch;
     return this.branch.trim();

--- a/readme.md
+++ b/readme.md
@@ -20,10 +20,15 @@ $ npx branch-name-lint --help
   Usage
     npx branch-name-lint [configfileLocation JSON|JS]
 
+  Options
+    --help   - to get this screen
+    --branch - specify a custom branch name to check instead of the current git branch
+
   Examples
     $ branch-name-lint
     $ branch-name-lint config-file.json
     $ branch-name-lint config-file.js
+    $ branch-name-lint --branch feature/my-new-feature
 ```
 
 ### CLI options.json
@@ -43,7 +48,7 @@ Any Valid JSON file with `branchNameLinter` attribute.
             "feat": "feature",
             "fix": "hotfix",
             "releases": "release"
-        },
+        ],
         "banned": [
             "wip"
         ],
@@ -56,6 +61,8 @@ Any Valid JSON file with `branchNameLinter` attribute.
             "staging"
         ],
         "separator": "/",
+        "branchNameEnvVariable": false,
+        "branch": false,
         "msgBranchBanned": "Branches with the name \"%s\" are not allowed.",
         "msgBranchDisallowed": "Pushing to \"%s\" is not allowed, use git-flow.",
         "msgPrefixNotAllowed": "Branch prefix \"%s\" is not allowed.",
@@ -64,6 +71,40 @@ Any Valid JSON file with `branchNameLinter` attribute.
     }
 }
 ```
+
+### Specifying a Custom Branch Name
+
+You can specify a custom branch name to validate instead of using the current git branch in two ways:
+
+1. Using the CLI flag:
+   ```
+   $ npx branch-name-lint --branch feature/my-custom-branch
+   ```
+
+2. Using configuration:
+   ```json
+   {
+     "branchNameLinter": {
+       "branch": "feature/my-custom-branch"
+     }
+   }
+   ```
+
+3. Using an environment variable:
+   ```json
+   {
+     "branchNameLinter": {
+       "branchNameEnvVariable": "CI_BRANCH_NAME"
+     }
+   }
+   ```
+
+   Then set the environment variable:
+   ```
+   CI_BRANCH_NAME=feature/my-custom-branch npx branch-name-lint
+   ```
+
+This is useful for CI/CD environments where you might want to validate branch names from environment variables.
 
 ### Disabling Checks
 

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ Any Valid JSON file with `branchNameLinter` attribute.
             "feat": "feature",
             "fix": "hotfix",
             "releases": "release"
-        ],
+        },
         "banned": [
             "wip"
         ],

--- a/tests/e2e-test.js
+++ b/tests/e2e-test.js
@@ -202,7 +202,7 @@ if (!badEnvVarResult.success) {
 
 // Test with a valid branch name via environment variable
 console.log('\n   Testing branchNameEnvVariable with a valid branch name:');
-runCommand(`TEST_BRANCH_NAME=feature/valid-env-branch npx branch-name-lint ${ENV_VAR_CONFIG_PATH}`);
+runCommand(`export TEST_BRANCH_NAME=feature/valid-env-branch npx branch-name-lint ${ENV_VAR_CONFIG_PATH}`);
 console.log('   ✅ Lint correctly passed for valid branch name provided via environment variable');
 
 // Clean up

--- a/tests/e2e-test.js
+++ b/tests/e2e-test.js
@@ -192,7 +192,10 @@ console.log(`   Created environment variable configuration at: ${ENV_VAR_CONFIG_
 
 // Test with an invalid branch name via environment variable
 console.log('\n   Testing branchNameEnvVariable with an invalid branch name:');
-const badEnvVarResult = runCommand(`TEST_BRANCH_NAME=invalid-env-branch npx branch-name-lint ${ENV_VAR_CONFIG_PATH}`, { expectError: true });
+const badEnvVarResult = runCommand(`npx branch-name-lint ${ENV_VAR_CONFIG_PATH}`, { 
+  expectError: true,
+  env: { ...process.env, TEST_BRANCH_NAME: "invalid-env-branch" }
+});
 if (!badEnvVarResult.success) {
   console.log('   ✅ Lint correctly failed for invalid branch name provided via environment variable');
 } else {
@@ -202,7 +205,9 @@ if (!badEnvVarResult.success) {
 
 // Test with a valid branch name via environment variable
 console.log('\n   Testing branchNameEnvVariable with a valid branch name:');
-runCommand(`export TEST_BRANCH_NAME=feature/valid-env-branch npx branch-name-lint ${ENV_VAR_CONFIG_PATH}`);
+runCommand(`npx branch-name-lint ${ENV_VAR_CONFIG_PATH}`, {
+  env: { ...process.env, TEST_BRANCH_NAME: "feature/valid-env-branch" }
+});
 console.log('   ✅ Lint correctly passed for valid branch name provided via environment variable');
 
 // Clean up


### PR DESCRIPTION
To allow setting up a custom branch name in the CI process, I added a `--branch` option and an env variable to the option; you can use one of those. I also added documentation about it with a GitHub actions example and added it to our workflow.

Fixes: #46 